### PR TITLE
Update mode-line-inactive face name

### DIFF
--- a/subatomic-theme.el
+++ b/subatomic-theme.el
@@ -123,7 +123,7 @@ The theme has to be reloaded after changing anything in this group."
    `(powerline-active2
      ((t (:background ,midnight-1))))
 
-   `(modeline-inactive
+   `(mode-line-inactive
      ((t (:background ,midnight-2 :foreground ,mystic-blue))))
 
    `(powerline-inactive1


### PR DESCRIPTION
The "modeline-inactive" face alias was obsoleted in v22.1 and removed in 2016.